### PR TITLE
Add SDK PII redaction docs to zeroeval-docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -17,6 +17,7 @@
             "group": "Tracing",
             "pages": [
               "tracing/introduction",
+              "tracing/pii-redaction",
               {
                 "group": "SDKs",
                 "pages": [
@@ -128,6 +129,11 @@
     ]
   },
   "contextual": {
-    "options": ["copy", "view", "chatgpt", "claude"]
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude"
+    ]
   }
 }

--- a/tracing/introduction.mdx
+++ b/tracing/introduction.mdx
@@ -63,3 +63,9 @@ Create an API key from [Settings → API Keys](https://app.zeroeval.com/settings
   skill](/integrations/skills) can handle SDK setup, first trace, and prompt
   migration for you.
 </Tip>
+
+<Note>
+  Need source-side PII redaction before span data is buffered, logged, or sent?
+  ZeroEval supports opt-in redaction in both SDKs. See [PII
+  redaction](/tracing/pii-redaction).
+</Note>

--- a/tracing/pii-redaction.mdx
+++ b/tracing/pii-redaction.mdx
@@ -1,0 +1,183 @@
+---
+title: "PII redaction"
+description: "Opt-in SDK-side redaction for tracing data in the Python and TypeScript SDKs"
+---
+
+ZeroEval supports opt-in source-side PII redaction in the Python and TypeScript
+SDKs. When enabled, sensitive values are redacted before spans are buffered,
+logged, or sent by the SDK.
+
+<Note>
+  This is an SDK-side feature. ZeroEval does not rely on backend-side redaction
+  for this behavior.
+</Note>
+
+## Enable redaction
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import zeroeval as ze
+
+    ze.init(
+        api_key="YOUR_API_KEY",
+        redaction={"enabled": True},
+    )
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import * as ze from "zeroeval";
+
+    ze.init({
+      apiKey: "YOUR_API_KEY",
+      redaction: { enabled: true },
+    });
+    ```
+  </Tab>
+</Tabs>
+
+You can also enable the default redaction toggle with:
+
+```bash
+export ZEROEVAL_REDACT_PII=true
+```
+
+Python uses snake_case nested keys such as `redact_inputs`,
+`redact_session_names`, `sensitive_keys`, and `custom_patterns`. TypeScript uses
+the camelCase equivalents `redactInputs`, `redactSessionNames`,
+`sensitiveKeys`, and `customPatterns`.
+
+## What gets redacted
+
+By default, the SDKs redact sensitive values found in:
+
+- inputs and outputs
+- attributes
+- error messages and stacks
+- session names
+- tag values
+
+Built-in detectors cover:
+
+- email addresses
+- phone numbers
+- SSN-style identifiers
+- PAN / credit card numbers
+- bearer tokens, JWTs, and common API key formats
+- cookie and authorization header values
+- IP addresses
+
+Key-based detection also force-redacts common sensitive fields such as
+`email`, `phone`, `password`, `token`, `authorization`, `cookie`, and
+`api_key` / `apiKey`.
+
+## What stays intact
+
+Redaction is meant to preserve trace structure. The SDKs keep:
+
+- span names
+- trace IDs and span IDs
+- timing and status fields
+- token counts, model/provider metadata, and cost metadata unless the value
+  itself is sensitive
+
+## Placeholder behavior
+
+Sensitive values are replaced with stable placeholders inside a single trace:
+
+```text
+alice@example.com -> [REDACTED_EMAIL_A]
+bob@example.com   -> [REDACTED_EMAIL_B]
+alice@example.com -> [REDACTED_EMAIL_A]
+```
+
+- the same normalized sensitive value in one trace gets the same placeholder
+- different values in the same trace get different placeholders
+- placeholder assignment resets per trace
+- matching is exact after normalization only
+- this is not fuzzy identity resolution
+
+That means repeated references across parent and child spans stay joinable
+without preserving the original value.
+
+## Normalization and limitations
+
+| Type | Normalization used for placeholder reuse |
+| --- | --- |
+| Email | Trim + lowercase |
+| Phone | Digits only |
+| SSN / PAN | Digits only |
+| IP | Canonical or lowercase string as implemented by each SDK |
+| Secrets | Exact trimmed string |
+
+Important limitations:
+
+- there is no reversible backend token vault
+- there is no de-anonymization support
+- there is no fuzzy entity resolution across semantically related strings
+- bypassing SDK capture paths bypasses this protection
+
+## Examples
+
+The SDK repositories include runnable examples that match the implemented
+behavior:
+
+<Tabs>
+  <Tab title="Python">
+    From `zeroeval-sdk/examples/pii_redaction.py`:
+
+    ```python
+    import zeroeval as ze
+
+    ze.init(
+        api_key="sk_ze_demo_local",
+        redaction={"enabled": True},
+    )
+
+    with ze.span(
+        name="pii-redaction-demo",
+        session={"id": "alice@example.com", "name": "Alice alice@example.com"},
+        tags={"customer_email": "alice@example.com"},
+    ) as span:
+        span.set_io(
+            input_data={"email": "alice@example.com", "phone": "+1 (415) 555-1234"},
+            output_data={"result": "Reach alice@example.com"},
+        )
+        span.set_error(
+            code="ValueError",
+            message="Failed for alice@example.com with Bearer secret-demo-token",
+        )
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    From `zeroeval-ts/examples/10-pii-redaction.ts`:
+
+    ```typescript
+    import * as ze from "zeroeval";
+
+    ze.init({
+      apiKey: "demo-api-key",
+      redaction: { enabled: true },
+    });
+
+    const span = ze.tracer.startSpan("demo.pii_redaction", {
+      sessionId: "alice@example.com",
+      sessionName: "Alice Example <alice@example.com>",
+      tags: { customer_email: "alice@example.com" },
+    });
+
+    span.setIO(
+      {
+        email: "alice@example.com",
+        phone: "+1 (415) 555-1212",
+        apiKey: "sk-live-abcdef1234567890",
+      },
+      "Send follow-up to alice@example.com and bob@example.com"
+    );
+    ```
+  </Tab>
+</Tabs>
+
+In both SDKs, repeated exact values such as the same email address will reuse
+the same placeholder within the trace.

--- a/tracing/sdks/python/reference.mdx
+++ b/tracing/sdks/python/reference.mdx
@@ -24,10 +24,11 @@ def init(
     api_url: str = None,
     disabled_integrations: list[str] = None,
     enabled_integrations: list[str] = None,
-    setup_otlp: bool = True,
+    setup_otlp: bool = False,
     service_name: str = "zeroeval-app",
     tags: dict[str, str] = None,
-    sampling_rate: float = None
+    sampling_rate: float = None,
+    redaction: dict[str, object] = None
 ) -> None
 ```
 
@@ -40,10 +41,11 @@ def init(
 | `api_url`               | `str`            | `"https://api.zeroeval.com"` | API endpoint URL                                  |
 | `disabled_integrations` | `list[str]`      | `None`                       | Integrations to disable (e.g. `["langchain"]`)    |
 | `enabled_integrations`  | `list[str]`      | `None`                       | Only enable these integrations                    |
-| `setup_otlp`            | `bool`           | `True`                       | Configure OpenTelemetry OTLP export               |
+| `setup_otlp`            | `bool`           | `False`                      | Configure OpenTelemetry OTLP export               |
 | `service_name`          | `str`            | `"zeroeval-app"`             | OTLP service name                                 |
 | `tags`                  | `dict[str, str]` | `None`                       | Global tags applied to all spans                  |
 | `sampling_rate`         | `float`          | `None`                       | Sampling rate 0.0-1.0 (1.0 = sample all)          |
+| `redaction`             | `dict[str, object]` | `None`                    | Source-side PII redaction settings                |
 
 **Example:**
 
@@ -54,9 +56,29 @@ ze.init(
     api_key="your-api-key",
     sampling_rate=0.1,
     disabled_integrations=["langchain"],
+    redaction={"enabled": True},
     debug=True
 )
 ```
+
+`redaction` uses snake_case keys in Python:
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | `bool` | `False` | Turn source-side redaction on |
+| `redact_inputs` | `bool` | `True` | Redact `input_data` |
+| `redact_outputs` | `bool` | `True` | Redact `output_data` |
+| `redact_attributes` | `bool` | `True` | Redact span attributes |
+| `redact_errors` | `bool` | `True` | Redact error messages and stacks |
+| `redact_session_names` | `bool` | `True` | Redact session names |
+| `redact_tag_values` | `bool` | `True` | Redact span, trace, and session tag values |
+| `sensitive_keys` | `list[str]` | built-in list | Force-redact matching keys such as `email`, `api_key`, `authorization`, and `cookie` |
+| `custom_patterns` | `list[Pattern[str] \| str]` | `[]` | Additional regex patterns to redact |
+
+<Tip>
+  See [PII redaction](/tracing/pii-redaction) for scope, placeholder behavior,
+  normalization rules, and examples.
+</Tip>
 
 ## Decorators
 
@@ -895,6 +917,7 @@ Set before importing ZeroEval to configure default behavior.
 | `ZEROEVAL_SAMPLING_RATE`         | float   | `"1.0"`                      | Sampling rate (0.0-1.0)                 |
 | `ZEROEVAL_DISABLED_INTEGRATIONS` | string  | `""`                         | Comma-separated integrations to disable |
 | `ZEROEVAL_DEBUG`                 | boolean | `"false"`                    | Enable debug logging                    |
+| `ZEROEVAL_REDACT_PII`            | boolean | `"false"`                    | Enable SDK-side PII redaction           |
 
 ```bash
 export ZEROEVAL_API_KEY="ze_1234567890abcdef"
@@ -919,6 +942,7 @@ ze.tracer.configure(
     flush_interval=0.5,
     max_spans=100,
     sampling_rate=0.05,
+    redaction={"enabled": True},
     integrations={"openai": True, "langchain": False}
 )
 ```

--- a/tracing/sdks/python/setup.mdx
+++ b/tracing/sdks/python/setup.mdx
@@ -34,6 +34,12 @@ ze.init(api_key="YOUR_API_KEY")
   `~/.config/zeroeval/config.json`
 </Note>
 
+<Tip>
+  Need source-side PII redaction? Pass `redaction={"enabled": True}` to
+  `ze.init(...)` or set `ZEROEVAL_REDACT_PII=true`. See [PII
+  redaction](/tracing/pii-redaction).
+</Tip>
+
 ## Patterns
 
 ### Decorators

--- a/tracing/sdks/typescript/reference.mdx
+++ b/tracing/sdks/typescript/reference.mdx
@@ -25,12 +25,13 @@ function init(opts?: InitOptions): void;
 | -------------------- | ------------------------- | -------------------------- | --------------------------------------- |
 | `apiKey`             | `string`                  | `ZEROEVAL_API_KEY` env     | Your ZeroEval API key                   |
 | `apiUrl`             | `string`                  | `https://api.zeroeval.com` | Custom API URL                          |
-| `workspaceName`      | `string`                  | `"Personal Organization"`  | Workspace/organization name             |
+| `workspaceName`      | `string`                  | `"Personal Workspace"`     | Workspace/organization name             |
 | `flushInterval`      | `number`                  | `10`                       | Interval in seconds to flush spans      |
 | `maxSpans`           | `number`                  | `100`                      | Maximum spans to buffer before flushing |
 | `collectCodeDetails` | `boolean`                 | `true`                     | Capture source code context             |
 | `integrations`       | `Record<string, boolean>` | —                          | Enable/disable specific integrations    |
 | `debug`              | `boolean`                 | `false`                    | Enable debug logging                    |
+| `redaction`          | `Partial<RedactionConfig>` | —                         | Source-side PII redaction settings      |
 
 #### Example
 
@@ -39,9 +40,29 @@ import * as ze from "zeroeval";
 
 ze.init({
   apiKey: "your-api-key",
+  redaction: { enabled: true },
   debug: true,
 });
 ```
+
+`redaction` uses camelCase keys in TypeScript:
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | `boolean` | `false` | Turn source-side redaction on |
+| `redactInputs` | `boolean` | `true` | Redact `input_data` |
+| `redactOutputs` | `boolean` | `true` | Redact `output_data` |
+| `redactAttributes` | `boolean` | `true` | Redact span attributes |
+| `redactErrors` | `boolean` | `true` | Redact error messages and stacks |
+| `redactSessionNames` | `boolean` | `true` | Redact session names |
+| `redactTagValues` | `boolean` | `true` | Redact span, trace, and session tag values |
+| `sensitiveKeys` | `string[]` | built-in list | Force-redact matching keys such as `email`, `apiKey`, `authorization`, and `cookie` |
+| `customPatterns` | `Array<RegExp \| string>` | `[]` | Additional patterns to redact |
+
+<Tip>
+  See [PII redaction](/tracing/pii-redaction) for scope, placeholder behavior,
+  normalization rules, and examples.
+</Tip>
 
 ---
 
@@ -408,6 +429,7 @@ Set before importing ZeroEval to configure default behavior.
 | `ZEROEVAL_SAMPLING_RATE`         | float   | `"1.0"`                      | Sampling rate (0.0-1.0)                 |
 | `ZEROEVAL_DISABLED_INTEGRATIONS` | string  | `""`                         | Comma-separated integrations to disable |
 | `ZEROEVAL_DEBUG`                 | boolean | `"false"`                    | Enable debug logging                    |
+| `ZEROEVAL_REDACT_PII`            | boolean | `"false"`                    | Enable SDK-side PII redaction           |
 
 ```bash
 export ZEROEVAL_API_KEY="ze_1234567890abcdef"

--- a/tracing/sdks/typescript/setup.mdx
+++ b/tracing/sdks/typescript/setup.mdx
@@ -41,6 +41,12 @@ ze.init({
 });
 ```
 
+<Tip>
+  Need source-side PII redaction? Pass `redaction: { enabled: true }` to
+  `init(...)` or set `ZEROEVAL_REDACT_PII=true`. See [PII
+  redaction](/tracing/pii-redaction).
+</Tip>
+
 ## Patterns
 
 The SDK offers two ways to add tracing to your TypeScript/JavaScript code:
@@ -251,6 +257,7 @@ ze.init({
   maxSpans: 200,              // Buffer up to 200 spans
   collectCodeDetails: true,   // Capture source code context
   debug: false,               // Enable debug logging
+  redaction: { enabled: true },
   integrations: {
     openai: true,             // Enable OpenAI integration
     vercelAI: true,           // Enable Vercel AI SDK integration


### PR DESCRIPTION
Adds SDK-side PII redaction documentation pages for Python and TypeScript tracing SDKs.

- New page `tracing/pii-redaction.mdx` with feature overview, enablement, scope, placeholder behavior, normalization, and examples
- Added `tracing/pii-redaction` to docs.json navigation after introduction
- Added Note to `tracing/introduction.mdx` linking to PII redaction
- Added Tip to `tracing/sdks/python/setup.mdx` with `redaction={"enabled": True}` and `ZEROEVAL_REDACT_PII=true` syntax
- Added Tip to `tracing/sdks/typescript/setup.mdx` with `redaction: { enabled: true }` and `ZEROEVAL_REDACT_PII=true` syntax
- Added `redaction` init parameter to `tracing/sdks/python/reference.mdx` with snake_case keys table (enabled, redact_inputs, redact_outputs, redact_attributes, redact_errors, redact_session_names, redact_tag_values, sensitive_keys, custom_patterns)
- Added `redaction` init option to `tracing/sdks/typescript/reference.mdx` with camelCase keys table (enabled, redactInputs, redactOutputs, redactAttributes, redactErrors, redactSessionNames, redactTagValues, sensitiveKeys, customPatterns)
- Added `ZEROEVAL_REDACT_PII` env var to both reference pages

<a href="https://capy.ai/project/b1c6ede2-717a-4dcf-8e77-9c048dc56142/pull/5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b1c6ede2-717a-4dcf-8e77-9c048dc56142/task/82ff7fa9-04c5-4890-b78b-0b8c6cc1a619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-8&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-8"><img alt="ZE-8 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=ZE-8"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add a new tracing guide and update Python/TypeScript SDK docs; low risk aside from potential confusion if the documented defaults/options diverge from SDK behavior.
> 
> **Overview**
> Adds a new *Tracing* guide page, `tracing/pii-redaction`, describing opt-in **SDK-side PII redaction** (what is redacted, placeholder behavior, normalization, limitations, and runnable examples for Python/TypeScript).
> 
> Updates navigation and entry points by linking the new page from `tracing/introduction` and adding setup tips in both SDK setup guides, plus extends Python/TypeScript SDK reference docs with a `redaction` init option (including key tables) and the `ZEROEVAL_REDACT_PII` env var; also tweaks Python `init` docs to show `setup_otlp` defaulting to `False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77090a05be862d6982daad8f608012b3fc694606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->